### PR TITLE
Remove saved token if its expired

### DIFF
--- a/build/request.js
+++ b/build/request.js
@@ -71,7 +71,9 @@ prepareOptions = function(options) {
       })["catch"](function(error) {
         if (error instanceof errors.ResinRequestError && error.statusCode === 401) {
           return token.get().then(function(sessionToken) {
-            throw new errors.ResinExpiredToken(sessionToken);
+            return token.remove().then(function() {
+              throw new errors.ResinExpiredToken(sessionToken);
+            });
           });
         }
         throw error;

--- a/lib/request.coffee
+++ b/lib/request.coffee
@@ -60,7 +60,8 @@ prepareOptions = (options = {}) ->
 				# us to safely assume the token is expired
 				if error instanceof errors.ResinRequestError and error.statusCode is 401
 					return token.get().then (sessionToken) ->
-						throw new errors.ResinExpiredToken(sessionToken)
+						token.remove().then ->
+							throw new errors.ResinExpiredToken(sessionToken)
 
 				throw error
 			.get('body')

--- a/tests/request.spec.coffee
+++ b/tests/request.spec.coffee
@@ -15,6 +15,8 @@ utils = require('../lib/utils')
 
 describe 'Request:', ->
 
+	@timeout(10000)
+
 	describe 'given the token is always fresh', ->
 
 		beforeEach ->

--- a/tests/request.spec.coffee
+++ b/tests/request.spec.coffee
@@ -580,6 +580,12 @@ describe 'Request:', ->
 						m.chai.expect(error.token).to.equal(johnDoeFixture.token)
 					.nodeify(done)
 
+				it 'should clear the token', (done) ->
+					request.send(url: '/foo').catch ->
+						token.has().then (hasToken) ->
+							m.chai.expect(hasToken).to.be.false
+					.nodeify(done)
+
 			describe 'given /whoami returns a non 401 status code', ->
 
 				beforeEach ->


### PR DESCRIPTION
Currently we throw an error if the token is expired, but keep it there.
The CLI intercepts this error and prints a friendly message asking the
user to login with `resin login`, however this command will attempt to
make some HTTP requests before performing the login, which will throw
the expired error again, and will ask the user to run `resin login` when
actually running `resin login`.