### PR TITLE
Prevent passing an undefined api_key query string

### DIFF
--- a/build/request.js
+++ b/build/request.js
@@ -81,7 +81,9 @@ prepareOptions = function(options) {
     if (authorizationHeader != null) {
       options.headers.Authorization = authorizationHeader;
     }
-    _.set(options, 'qs.api_key', process.env.RESIN_API_KEY || void 0);
+    if (!_.isEmpty(process.env.RESIN_API_KEY)) {
+      _.set(options, 'qs.api_key', process.env.RESIN_API_KEY);
+    }
     return options;
   });
 };

--- a/lib/request.coffee
+++ b/lib/request.coffee
@@ -72,7 +72,8 @@ prepareOptions = (options = {}) ->
 		if authorizationHeader?
 			options.headers.Authorization = authorizationHeader
 
-		_.set(options, 'qs.api_key', process.env.RESIN_API_KEY or undefined)
+		if not _.isEmpty(process.env.RESIN_API_KEY)
+			_.set(options, 'qs.api_key', process.env.RESIN_API_KEY)
 
 		return options
 

--- a/tests/api-key.spec.coffee
+++ b/tests/api-key.spec.coffee
@@ -21,6 +21,30 @@ describe 'Request (api key):', ->
 		afterEach ->
 			@utilsShouldUpdateToken.restore()
 
+		describe 'given a simple GET endpoint containing special characters in query strings', ->
+
+			beforeEach ->
+				nock(settings.get('apiUrl'))
+					.get('/foo?$bar=baz')
+					.reply(200)
+
+			afterEach ->
+				nock.cleanAll()
+
+			describe 'given no api key', ->
+
+				beforeEach ->
+					process.env.RESIN_API_KEY = ''
+
+				it 'should not encode special characters automatically', ->
+					promise = request.send
+						method: 'GET'
+						url: '/foo?$bar=baz'
+					.get('request')
+					.get('uri')
+					.get('path')
+					m.chai.expect(promise).to.eventually.equal('/foo?$bar=baz')
+
 		describe 'given a simple GET endpoint', ->
 
 			beforeEach ->


### PR DESCRIPTION
We've encountered a weird edge case where if we pass an `undefined`
query string to `request`, like

```json
{
	"qs": {
		"api_key": undefined
	}
}
```

It will cause `request` to URL-encode any special character in the URL
after the query question sign.

So for example, `/foo?$bar=baz` would become `/foo?%24bar=baz`, and thus
will fail to match the intended route.