### PR TITLE
Decouple resin-request from resin-settings-client

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,9 @@ Documentation
     * [.stream(options)](#module_request.stream) ⇒ <code>Promise.&lt;Stream&gt;</code>
 
 <a name="module_request.send"></a>
+
 ### request.send(options) ⇒ <code>Promise.&lt;Object&gt;</code>
-This function automatically handles authorization with Resin.io and automatically prepends the Resin.io host, therefore you should pass relative urls.
+This function automatically handles authorization with Resin.io.
 
 The module scans your environment for a saved session token, or an environment variable called `RESIN_API_KEY`. If none of these are found, the request is made anonymously.
 
@@ -57,6 +58,7 @@ The module scans your environment for a saved session token, or an environment v
 ```js
 request.send
 	method: 'GET'
+	baseUrl: 'https://api.resin.io'
 	url: '/foo'
 .get('body')
 ```
@@ -64,12 +66,14 @@ request.send
 ```js
 request.send
 	method: 'POST'
+	baseUrl: 'https://api.resin.io'
 	url: '/bar'
 	data:
 		hello: 'world'
 .get('body')
 ```
 <a name="module_request.stream"></a>
+
 ### request.stream(options) ⇒ <code>Promise.&lt;Stream&gt;</code>
 This function emits a `progress` event, passing an object with the following properties:
 
@@ -100,6 +104,7 @@ See `request.send()` for an explanation on how this function handles authenticat
 ```js
 request.stream
 	method: 'GET'
+	baseUrl: 'https://img.resin.io'
 	url: '/download/foo'
 .then (stream) ->
 	stream.on 'progress', (state) ->

--- a/build/request.js
+++ b/build/request.js
@@ -18,7 +18,7 @@ limitations under the License.
 /**
  * @module request
  */
-var Promise, _, errors, prepareOptions, progress, request, requestAsync, rindle, settings, token, url, utils;
+var Promise, _, errors, prepareOptions, progress, request, requestAsync, rindle, token, url, utils;
 
 Promise = require('bluebird');
 
@@ -33,8 +33,6 @@ _ = require('lodash');
 rindle = require('rindle');
 
 errors = require('resin-errors');
-
-settings = require('resin-settings-client');
 
 token = require('resin-token');
 
@@ -54,9 +52,6 @@ prepareOptions = function(options) {
     headers: {},
     refreshToken: true
   });
-  if (options.baseUrl == null) {
-    options.url = url.resolve(settings.get('apiUrl'), options.url);
-  }
   return Promise["try"](function() {
     if (!options.refreshToken) {
       return;
@@ -67,6 +62,7 @@ prepareOptions = function(options) {
       }
       return exports.send({
         url: '/whoami',
+        baseUrl: options.baseUrl,
         refreshToken: false
       })["catch"]({
         name: 'ResinRequestError',
@@ -96,7 +92,7 @@ prepareOptions = function(options) {
  * @public
  *
  * @description
- * This function automatically handles authorization with Resin.io and automatically prepends the Resin.io host, therefore you should pass relative urls.
+ * This function automatically handles authorization with Resin.io.
  *
  * The module scans your environment for a saved session token, or an environment variable called `RESIN_API_KEY`. If none of these are found, the request is made anonymously.
  *
@@ -110,12 +106,14 @@ prepareOptions = function(options) {
  * @example
  * request.send
  * 	method: 'GET'
+ * 	baseUrl: 'https://api.resin.io'
  * 	url: '/foo'
  * .get('body')
  *
  * @example
  * request.send
  * 	method: 'POST'
+ * 	baseUrl: 'https://api.resin.io'
  * 	url: '/bar'
  * 	data:
  * 		hello: 'world'
@@ -170,6 +168,7 @@ exports.send = function(options) {
  * @example
  * request.stream
  * 	method: 'GET'
+ * 	baseUrl: 'https://img.resin.io'
  * 	url: '/download/foo'
  * .then (stream) ->
  * 	stream.on 'progress', (state) ->

--- a/lib/request.coffee
+++ b/lib/request.coffee
@@ -26,7 +26,6 @@ _ = require('lodash')
 rindle = require('rindle')
 
 errors = require('resin-errors')
-settings = require('resin-settings-client')
 token = require('resin-token')
 utils = require('./utils')
 progress = require('./progress')
@@ -41,9 +40,6 @@ prepareOptions = (options = {}) ->
 		headers: {}
 		refreshToken: true
 
-	if not options.baseUrl?
-		options.url = url.resolve(settings.get('apiUrl'), options.url)
-
 	Promise.try ->
 		return if not options.refreshToken
 
@@ -52,6 +48,7 @@ prepareOptions = (options = {}) ->
 
 			exports.send
 				url: '/whoami'
+				baseUrl: options.baseUrl
 				refreshToken: false
 
 			# At this point we're sure there is a saved token,
@@ -91,7 +88,7 @@ prepareOptions = (options = {}) ->
 # @public
 #
 # @description
-# This function automatically handles authorization with Resin.io and automatically prepends the Resin.io host, therefore you should pass relative urls.
+# This function automatically handles authorization with Resin.io.
 #
 # The module scans your environment for a saved session token, or an environment variable called `RESIN_API_KEY`. If none of these are found, the request is made anonymously.
 #
@@ -105,12 +102,14 @@ prepareOptions = (options = {}) ->
 # @example
 # request.send
 # 	method: 'GET'
+# 	baseUrl: 'https://api.resin.io'
 # 	url: '/foo'
 # .get('body')
 #
 # @example
 # request.send
 # 	method: 'POST'
+# 	baseUrl: 'https://api.resin.io'
 # 	url: '/bar'
 # 	data:
 # 		hello: 'world'
@@ -161,6 +160,7 @@ exports.send = (options = {}) ->
 # @example
 # request.stream
 # 	method: 'GET'
+# 	baseUrl: 'https://img.resin.io'
 # 	url: '/download/foo'
 # .then (stream) ->
 # 	stream.on 'progress', (state) ->

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "progress-stream": "^1.1.1",
     "request": "^2.53.0",
     "resin-errors": "^2.3.0",
-    "resin-settings-client": "^3.0.0",
     "resin-token": "^2.4.1",
     "rindle": "^1.2.0"
   }

--- a/tests/api-key.spec.coffee
+++ b/tests/api-key.spec.coffee
@@ -2,7 +2,6 @@ Promise = require('bluebird')
 m = require('mochainon')
 nock = require('nock')
 rindle = require('rindle')
-settings = require('resin-settings-client')
 token = require('resin-token')
 johnDoeFixture = require('./tokens.json').johndoe
 request = require('../lib/request')
@@ -24,7 +23,7 @@ describe 'Request (api key):', ->
 		describe 'given a simple GET endpoint containing special characters in query strings', ->
 
 			beforeEach ->
-				nock(settings.get('apiUrl'))
+				nock('https://api.resin.io')
 					.get('/foo')
 					.query(true)
 					.reply(200)
@@ -40,6 +39,7 @@ describe 'Request (api key):', ->
 				it 'should not encode special characters automatically', ->
 					promise = request.send
 						method: 'GET'
+						baseUrl: 'https://api.resin.io'
 						url: '/foo?$bar=baz'
 					.get('request')
 					.get('uri')
@@ -57,6 +57,7 @@ describe 'Request (api key):', ->
 				it 'should not encode special characters automatically', ->
 					promise = request.send
 						method: 'GET'
+						baseUrl: 'https://api.resin.io'
 						url: '/foo?$bar=baz'
 					.get('request')
 					.get('uri')
@@ -66,7 +67,7 @@ describe 'Request (api key):', ->
 		describe 'given a simple GET endpoint', ->
 
 			beforeEach ->
-				nock(settings.get('apiUrl')).get('/foo').query(true).reply(200, 'Foo Bar')
+				nock('https://api.resin.io').get('/foo').query(true).reply(200, 'Foo Bar')
 
 			afterEach ->
 				nock.cleanAll()
@@ -89,6 +90,7 @@ describe 'Request (api key):', ->
 						it 'should pass an api_key query string', ->
 							promise = request.send
 								method: 'GET'
+								baseUrl: 'https://api.resin.io'
 								url: '/foo'
 							.get('request')
 							.get('uri')
@@ -100,6 +102,7 @@ describe 'Request (api key):', ->
 						it 'should pass an api_key query string', (done) ->
 							request.stream
 								method: 'GET'
+								baseUrl: 'https://api.resin.io'
 								url: '/foo'
 							.then (stream) ->
 								m.chai.expect(stream.response.request.uri.query).to.equal('api_key=123456789')
@@ -115,6 +118,7 @@ describe 'Request (api key):', ->
 						it 'should pass an api_key query string', ->
 							promise = request.send
 								method: 'GET'
+								baseUrl: 'https://api.resin.io'
 								url: '/foo'
 							.get('request')
 							.get('uri')
@@ -124,6 +128,7 @@ describe 'Request (api key):', ->
 						it 'should still send an Authorization header', ->
 							promise = request.send
 								method: 'GET'
+								baseUrl: 'https://api.resin.io'
 								url: '/foo'
 							.get('request')
 							.get('headers')
@@ -135,6 +140,7 @@ describe 'Request (api key):', ->
 						it 'should pass an api_key query string', (done) ->
 							request.stream
 								method: 'GET'
+								baseUrl: 'https://api.resin.io'
 								url: '/foo'
 							.then (stream) ->
 								m.chai.expect(stream.response.request.uri.query).to.equal('api_key=123456789')
@@ -143,6 +149,7 @@ describe 'Request (api key):', ->
 						it 'should still send an Authorization header', (done) ->
 							request.stream
 								method: 'GET'
+								baseUrl: 'https://api.resin.io'
 								url: '/foo'
 							.then (stream) ->
 								headers = stream.response.request.headers
@@ -164,6 +171,7 @@ describe 'Request (api key):', ->
 						it 'should not pass an api_key query string', ->
 							promise = request.send
 								method: 'GET'
+								baseUrl: 'https://api.resin.io'
 								url: '/foo'
 							.get('request')
 							.get('uri')
@@ -173,6 +181,7 @@ describe 'Request (api key):', ->
 						it 'should not pass an api_key query string', ->
 							promise = request.send
 								method: 'GET'
+								baseUrl: 'https://api.resin.io'
 								url: '/foo'
 							.get('request')
 							.get('uri')
@@ -184,6 +193,7 @@ describe 'Request (api key):', ->
 						it 'should not pass an api_key query string', (done) ->
 							request.stream
 								method: 'GET'
+								baseUrl: 'https://api.resin.io'
 								url: '/foo'
 							.then (stream) ->
 								m.chai.expect(stream.response.request.uri.query).to.not.exist

--- a/tests/request.spec.coffee
+++ b/tests/request.spec.coffee
@@ -1,7 +1,6 @@
 m = require('mochainon')
 nock = require('nock')
 token = require('resin-token')
-settings = require('resin-settings-client')
 request = require('../lib/request')
 
 describe 'Request:', ->
@@ -16,7 +15,7 @@ describe 'Request:', ->
 		describe 'given a simple GET endpoint', ->
 
 			beforeEach ->
-				nock(settings.get('apiUrl')).get('/foo').reply(200, from: 'resin')
+				nock('https://api.resin.io').get('/foo').reply(200, from: 'resin')
 
 			afterEach ->
 				nock.cleanAll()
@@ -47,7 +46,7 @@ describe 'Request:', ->
 		describe 'given multiple endpoints', ->
 
 			beforeEach ->
-				nock(settings.get('apiUrl'))
+				nock('https://api.resin.io')
 					.get('/foo').reply(200, method: 'GET')
 					.post('/foo').reply(200, method: 'POST')
 					.put('/foo').reply(200, method: 'PUT')
@@ -59,6 +58,7 @@ describe 'Request:', ->
 
 			it 'should default to GET', ->
 				promise = request.send
+					baseUrl: 'https://api.resin.io'
 					url: '/foo'
 				.get('body')
 				m.chai.expect(promise).to.eventually.become(method: 'GET')
@@ -66,7 +66,7 @@ describe 'Request:', ->
 		describe 'given an endpoint that returns a non json response', ->
 
 			beforeEach ->
-				nock(settings.get('apiUrl')).get('/foo').reply(200, 'Hello World')
+				nock('https://api.resin.io').get('/foo').reply(200, 'Hello World')
 
 			afterEach ->
 				nock.cleanAll()
@@ -74,6 +74,7 @@ describe 'Request:', ->
 			it 'should resolve with the plain body', ->
 				promise = request.send
 					method: 'GET'
+					baseUrl: 'https://api.resin.io'
 					url: '/foo'
 				.get('body')
 				m.chai.expect(promise).to.eventually.equal('Hello World')
@@ -81,7 +82,7 @@ describe 'Request:', ->
 		describe 'given an endpoint that accepts a non json body', ->
 
 			beforeEach ->
-				nock(settings.get('apiUrl')).post('/foo').reply 200, (uri, body) ->
+				nock('https://api.resin.io').post('/foo').reply 200, (uri, body) ->
 					return "The body is: #{body}"
 
 			afterEach ->
@@ -90,6 +91,7 @@ describe 'Request:', ->
 			it 'should take the plain body successfully', ->
 				promise = request.send
 					method: 'POST'
+					baseUrl: 'https://api.resin.io'
 					url: '/foo'
 					body: 'Qux'
 				.get('body')
@@ -102,7 +104,7 @@ describe 'Request:', ->
 				describe 'given no response error', ->
 
 					beforeEach ->
-						nock(settings.get('apiUrl')).get('/foo').reply(200, hello: 'world')
+						nock('https://api.resin.io').get('/foo').reply(200, hello: 'world')
 
 					afterEach ->
 						nock.cleanAll()
@@ -110,6 +112,7 @@ describe 'Request:', ->
 					it 'should correctly make the request', ->
 						promise = request.send
 							method: 'GET'
+							baseUrl: 'https://api.resin.io'
 							url: '/foo'
 						.get('body')
 						m.chai.expect(promise).to.eventually.become(hello: 'world')
@@ -117,7 +120,7 @@ describe 'Request:', ->
 				describe 'given a response error', ->
 
 					beforeEach ->
-						nock(settings.get('apiUrl')).get('/foo').reply(500, error: text: 'Server Error')
+						nock('https://api.resin.io').get('/foo').reply(500, error: text: 'Server Error')
 
 					afterEach ->
 						nock.cleanAll()
@@ -125,12 +128,14 @@ describe 'Request:', ->
 					it 'should be rejected with the error message', ->
 						promise = request.send
 							method: 'GET'
+							baseUrl: 'https://api.resin.io'
 							url: '/foo'
 						m.chai.expect(promise).to.be.rejectedWith('Server Error')
 
 					it 'should have the status code in the error object', (done) ->
 						request.send
 							method: 'GET'
+							baseUrl: 'https://api.resin.io'
 							url: '/foo'
 						.catch (error) ->
 							m.chai.expect(error.statusCode).to.equal(500)
@@ -141,7 +146,7 @@ describe 'Request:', ->
 				describe 'given no response error', ->
 
 					beforeEach ->
-						nock(settings.get('apiUrl')).head('/foo').reply(200)
+						nock('https://api.resin.io').head('/foo').reply(200)
 
 					afterEach ->
 						nock.cleanAll()
@@ -149,6 +154,7 @@ describe 'Request:', ->
 					it 'should correctly make the request', ->
 						promise = request.send
 							method: 'HEAD'
+							baseUrl: 'https://api.resin.io'
 							url: '/foo'
 						.get('statusCode')
 						m.chai.expect(promise).to.eventually.equal(200)
@@ -156,7 +162,7 @@ describe 'Request:', ->
 				describe 'given a response error', ->
 
 					beforeEach ->
-						nock(settings.get('apiUrl')).head('/foo').reply(500)
+						nock('https://api.resin.io').head('/foo').reply(500)
 
 					afterEach ->
 						nock.cleanAll()
@@ -164,6 +170,7 @@ describe 'Request:', ->
 					it 'should be rejected with a generic error message', ->
 						promise = request.send
 							method: 'HEAD'
+							baseUrl: 'https://api.resin.io'
 							url: '/foo'
 						.get('statusCode')
 						m.chai.expect(promise).to.be.rejectedWith('The request was unsuccessful')
@@ -173,7 +180,7 @@ describe 'Request:', ->
 			describe 'given a POST endpoint that mirrors the request body', ->
 
 				beforeEach ->
-					nock(settings.get('apiUrl')).post('/foo').reply 200, (uri, body) ->
+					nock('https://api.resin.io').post('/foo').reply 200, (uri, body) ->
 						return body
 
 				afterEach ->
@@ -182,6 +189,7 @@ describe 'Request:', ->
 				it 'should eventually return the body', ->
 					promise = request.send
 						method: 'POST'
+						baseUrl: 'https://api.resin.io'
 						url: '/foo'
 						body:
 							foo: 'bar'
@@ -191,7 +199,7 @@ describe 'Request:', ->
 			describe 'given a PUT endpoint that mirrors the request body', ->
 
 				beforeEach ->
-					nock(settings.get('apiUrl')).put('/foo').reply 200, (uri, body) ->
+					nock('https://api.resin.io').put('/foo').reply 200, (uri, body) ->
 						return body
 
 				afterEach ->
@@ -200,6 +208,7 @@ describe 'Request:', ->
 				it 'should eventually return the body', ->
 					promise = request.send
 						method: 'PUT'
+						baseUrl: 'https://api.resin.io'
 						url: '/foo'
 						body:
 							foo: 'bar'
@@ -209,7 +218,7 @@ describe 'Request:', ->
 			describe 'given a PATCH endpoint that mirrors the request body', ->
 
 				beforeEach ->
-					nock(settings.get('apiUrl')).patch('/foo').reply 200, (uri, body) ->
+					nock('https://api.resin.io').patch('/foo').reply 200, (uri, body) ->
 						return body
 
 				afterEach ->
@@ -218,6 +227,7 @@ describe 'Request:', ->
 				it 'should eventually return the body', ->
 					promise = request.send
 						method: 'PATCH'
+						baseUrl: 'https://api.resin.io'
 						url: '/foo'
 						body:
 							foo: 'bar'
@@ -227,7 +237,7 @@ describe 'Request:', ->
 			describe 'given a DELETE endpoint that mirrors the request body', ->
 
 				beforeEach ->
-					nock(settings.get('apiUrl')).delete('/foo').reply 200, (uri, body) ->
+					nock('https://api.resin.io').delete('/foo').reply 200, (uri, body) ->
 						return body
 
 				afterEach ->
@@ -236,6 +246,7 @@ describe 'Request:', ->
 				it 'should eventually return the body', ->
 					promise = request.send
 						method: 'DELETE'
+						baseUrl: 'https://api.resin.io'
 						url: '/foo'
 						body:
 							foo: 'bar'

--- a/tests/stream.spec.coffee
+++ b/tests/stream.spec.coffee
@@ -4,7 +4,6 @@ nock = require('nock')
 zlib = require('zlib')
 PassThrough = require('stream').PassThrough
 token = require('resin-token')
-settings = require('resin-settings-client')
 rindle = require('rindle')
 request = require('../lib/request')
 
@@ -16,7 +15,7 @@ describe 'Request (stream):', ->
 	describe 'given a simple endpoint that responds with an error', ->
 
 		beforeEach ->
-			nock(settings.get('apiUrl')).get('/foo').reply(400, 'Something happened')
+			nock('https://api.resin.io').get('/foo').reply(400, 'Something happened')
 
 		afterEach ->
 			nock.cleanAll()
@@ -24,6 +23,7 @@ describe 'Request (stream):', ->
 		it 'should reject with the error message', ->
 			promise = request.stream
 				method: 'GET'
+				baseUrl: 'https://api.resin.io'
 				url: '/foo'
 
 			m.chai.expect(promise).to.be.rejectedWith('Something happened')
@@ -31,6 +31,7 @@ describe 'Request (stream):', ->
 		it 'should have the status code in the error object', (done) ->
 			request.stream
 				method: 'GET'
+				baseUrl: 'https://api.resin.io'
 				url: '/foo'
 			.catch (error) ->
 				m.chai.expect(error.statusCode).to.equal(400)
@@ -39,7 +40,7 @@ describe 'Request (stream):', ->
 	describe 'given a simple endpoint that responds with a string', ->
 
 		beforeEach ->
-			nock(settings.get('apiUrl')).get('/foo').reply(200, 'Lorem ipsum dolor sit amet')
+			nock('https://api.resin.io').get('/foo').reply(200, 'Lorem ipsum dolor sit amet')
 
 		afterEach ->
 			nock.cleanAll()
@@ -47,6 +48,7 @@ describe 'Request (stream):', ->
 		it 'should be able to pipe the response', (done) ->
 			request.stream
 				method: 'GET'
+				baseUrl: 'https://api.resin.io'
 				url: '/foo'
 			.then(rindle.extract).then (data) ->
 				m.chai.expect(data).to.equal('Lorem ipsum dolor sit amet')
@@ -55,6 +57,7 @@ describe 'Request (stream):', ->
 		it 'should be able to pipe the response after a delay', (done) ->
 			request.stream
 				method: 'GET'
+				baseUrl: 'https://api.resin.io'
 				url: '/foo'
 			.then (stream) ->
 				return Promise.delay(200).return(stream)
@@ -69,7 +72,7 @@ describe 'Request (stream):', ->
 	describe 'given multiple endpoints', ->
 
 		beforeEach ->
-			nock(settings.get('apiUrl'))
+			nock('https://api.resin.io')
 				.get('/foo').reply(200, 'GET')
 				.post('/foo').reply(200, 'POST')
 				.put('/foo').reply(200, 'PUT')
@@ -83,6 +86,7 @@ describe 'Request (stream):', ->
 
 			it 'should default to GET', (done) ->
 				request.stream
+					baseUrl: 'https://api.resin.io'
 					url: '/foo'
 				.then(rindle.extract).then (data) ->
 					m.chai.expect(data).to.equal('GET')
@@ -94,7 +98,7 @@ describe 'Request (stream):', ->
 			message = 'Lorem ipsum dolor sit amet'
 			zlib.gzip message, (error, compressedMessage) ->
 				return done(error) if error?
-				nock(settings.get('apiUrl'))
+				nock('https://api.resin.io')
 					.get('/foo')
 					.reply 200, compressedMessage,
 						'X-Transfer-Length': String(compressedMessage.length)
@@ -107,6 +111,7 @@ describe 'Request (stream):', ->
 
 		it 'should correctly uncompress the body', (done) ->
 			request.stream
+				baseUrl: 'https://api.resin.io'
 				url: '/foo'
 			.then (stream) ->
 				return rindle.extract(stream)
@@ -117,6 +122,7 @@ describe 'Request (stream):', ->
 
 		it 'should set no .length property', (done) ->
 			request.stream
+				baseUrl: 'https://api.resin.io'
 				url: '/foo'
 			.then (stream) ->
 				m.chai.expect(stream.length).to.be.undefined
@@ -128,7 +134,7 @@ describe 'Request (stream):', ->
 			message = 'Lorem ipsum dolor sit amet'
 			zlib.gzip message, (error, compressedMessage) ->
 				return done(error) if error?
-				nock(settings.get('apiUrl'))
+				nock('https://api.resin.io')
 					.get('/foo')
 					.reply 200, compressedMessage,
 						'Content-Length': String(message.length)
@@ -140,6 +146,7 @@ describe 'Request (stream):', ->
 
 		it 'should correctly uncompress the body', (done) ->
 			request.stream
+				baseUrl: 'https://api.resin.io'
 				url: '/foo'
 			.then (stream) ->
 				return rindle.extract(stream)
@@ -154,7 +161,7 @@ describe 'Request (stream):', ->
 			message = 'Lorem ipsum dolor sit amet'
 			zlib.gzip message, (error, compressedMessage) ->
 				return done(error) if error?
-				nock(settings.get('apiUrl'))
+				nock('https://api.resin.io')
 					.get('/foo')
 					.reply 200, compressedMessage,
 						'X-Transfer-Length': String(compressedMessage.length)
@@ -167,6 +174,7 @@ describe 'Request (stream):', ->
 
 		it 'should correctly uncompress the body', (done) ->
 			request.stream
+				baseUrl: 'https://api.resin.io'
 				url: '/foo'
 			.then (stream) ->
 				return rindle.extract(stream)
@@ -179,7 +187,7 @@ describe 'Request (stream):', ->
 
 		beforeEach ->
 			message = 'Lorem ipsum dolor sit amet'
-			nock(settings.get('apiUrl'))
+			nock('https://api.resin.io')
 				.get('/foo').reply(200, message, 'Content-Length': 'Hello')
 
 		afterEach ->
@@ -187,6 +195,7 @@ describe 'Request (stream):', ->
 
 		it 'should become a stream with an undefined length property', (done) ->
 			request.stream
+				baseUrl: 'https://api.resin.io'
 				url: '/foo'
 			.then (stream) ->
 				m.chai.expect(stream.length).to.be.undefined
@@ -196,7 +205,7 @@ describe 'Request (stream):', ->
 
 		beforeEach ->
 			message = 'Lorem ipsum dolor sit amet'
-			nock(settings.get('apiUrl'))
+			nock('https://api.resin.io')
 				.get('/foo').reply(200, message, 'Content-Type': 'application/octet-stream')
 
 		afterEach ->
@@ -204,6 +213,7 @@ describe 'Request (stream):', ->
 
 		it 'should become a stream with a mime property', (done) ->
 			request.stream
+				baseUrl: 'https://api.resin.io'
 				url: '/foo'
 			.then (stream) ->
 				m.chai.expect(stream.mime).to.equal('application/octet-stream')

--- a/tests/token.spec.coffee
+++ b/tests/token.spec.coffee
@@ -1,7 +1,6 @@
 Promise = require('bluebird')
 m = require('mochainon')
 nock = require('nock')
-settings = require('resin-settings-client')
 errors = require('resin-errors')
 rindle = require('rindle')
 token = require('resin-token')
@@ -20,7 +19,7 @@ describe 'Request (token):', ->
 		describe 'given a simple GET endpoint', ->
 
 			beforeEach ->
-				nock(settings.get('apiUrl')).get('/foo').reply(200, 'bar')
+				nock('https://api.resin.io').get('/foo').reply(200, 'bar')
 
 			afterEach ->
 				nock.cleanAll()
@@ -42,6 +41,7 @@ describe 'Request (token):', ->
 					it 'should send an Authorization header', ->
 						promise = request.send
 							method: 'GET'
+							baseUrl: 'https://api.resin.io'
 							url: '/foo'
 						.get('request')
 						.get('headers')
@@ -56,6 +56,7 @@ describe 'Request (token):', ->
 					it 'should not send an Authorization header', ->
 						promise = request.send
 							method: 'GET'
+							baseUrl: 'https://api.resin.io'
 							url: '/foo'
 						.get('request')
 						.get('headers')
@@ -77,7 +78,7 @@ describe 'Request (token):', ->
 				describe 'given a working /whoami endpoint', ->
 
 					beforeEach ->
-						nock(settings.get('apiUrl'))
+						nock('https://api.resin.io')
 							.get('/whoami')
 							.reply(200, janeDoeFixture.token)
 
@@ -87,7 +88,9 @@ describe 'Request (token):', ->
 					it 'should refresh the token', (done) ->
 						token.get().then (savedToken) ->
 							m.chai.expect(savedToken).to.equal(johnDoeFixture.token)
-							return request.send(url: '/foo')
+							return request.send
+								baseUrl: 'https://api.resin.io'
+								url: '/foo'
 						.then (response) ->
 							m.chai.expect(response.body).to.equal('bar')
 							return token.get()
@@ -101,7 +104,10 @@ describe 'Request (token):', ->
 					# to simplicity.
 					it 'should use the new token in the same request', (done) ->
 						m.chai.expect(token.get()).to.eventually.equal(johnDoeFixture.token)
-						request.send(url: '/foo').then (response) ->
+						request.send
+							baseUrl: 'https://api.resin.io'
+							url: '/foo'
+						.then (response) ->
 							authorizationHeader = response.request.headers.Authorization
 							m.chai.expect(authorizationHeader).to.equal("Bearer #{janeDoeFixture.token}")
 						.nodeify(done)
@@ -109,7 +115,7 @@ describe 'Request (token):', ->
 				describe 'given /whoami returns 401', ->
 
 					beforeEach ->
-						nock(settings.get('apiUrl'))
+						nock('https://api.resin.io')
 							.get('/whoami')
 							.reply(401, 'Unauthorized')
 
@@ -117,16 +123,24 @@ describe 'Request (token):', ->
 						nock.cleanAll()
 
 					it 'should be rejected with an expiration error', ->
-						promise = request.send(url: '/foo')
+						promise = request.send
+							baseUrl: 'https://api.resin.io'
+							url: '/foo'
 						m.chai.expect(promise).to.be.rejectedWith(errors.ResinExpiredToken)
 
 					it 'should have the session token as an error attribute', (done) ->
-						request.send(url: '/foo').catch (error) ->
+						request.send
+							baseUrl: 'https://api.resin.io'
+							url: '/foo'
+						.catch (error) ->
 							m.chai.expect(error.token).to.equal(johnDoeFixture.token)
 						.nodeify(done)
 
 					it 'should clear the token', (done) ->
-						request.send(url: '/foo').catch ->
+						request.send
+							baseUrl: 'https://api.resin.io'
+							url: '/foo'
+						.catch ->
 							token.has().then (hasToken) ->
 								m.chai.expect(hasToken).to.be.false
 						.nodeify(done)
@@ -134,7 +148,7 @@ describe 'Request (token):', ->
 				describe 'given /whoami returns a non 401 status code', ->
 
 					beforeEach ->
-						nock(settings.get('apiUrl'))
+						nock('https://api.resin.io')
 							.get('/whoami')
 							.reply(500)
 
@@ -142,7 +156,9 @@ describe 'Request (token):', ->
 						nock.cleanAll()
 
 					it 'should be rejected with a request error', ->
-						promise = request.send(url: '/foo')
+						promise = request.send
+							baseUrl: 'https://api.resin.io'
+							url: '/foo'
 						m.chai.expect(promise).to.be.rejectedWith(errors.ResinRequestError)
 
 	describe '.stream()', ->
@@ -150,7 +166,7 @@ describe 'Request (token):', ->
 		describe 'given a simple endpoint that responds with a string', ->
 
 			beforeEach ->
-				nock(settings.get('apiUrl')).get('/foo').reply(200, 'Lorem ipsum dolor sit amet')
+				nock('https://api.resin.io').get('/foo').reply(200, 'Lorem ipsum dolor sit amet')
 
 			afterEach ->
 				nock.cleanAll()
@@ -172,6 +188,7 @@ describe 'Request (token):', ->
 					it 'should send an Authorization header', (done) ->
 						request.stream
 							method: 'GET'
+							baseUrl: 'https://api.resin.io'
 							url: '/foo'
 						.then (stream) ->
 							headers = stream.response.request.headers
@@ -186,6 +203,7 @@ describe 'Request (token):', ->
 					it 'should not send an Authorization header', (done) ->
 						request.stream
 							method: 'GET'
+							baseUrl: 'https://api.resin.io'
 							url: '/foo'
 						.then (stream) ->
 							headers = stream.response.request.headers


### PR DESCRIPTION
This PR is part of the process of refactoring the Resin SDK to decouple it
from the environment to easy porting it to the browser.