### PR TITLE
update resin-token and add browser tests runner

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: node_js
 before_install:
   - npm install -g npm@latest
 node_js:
+  - "6"
+  - "4"
   - "0.12"
-  - "0.11"
-  - "0.10"
 notifications:
   email: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+### Changed
+
+- Updated `resin-token` to v2.4.3
+- Run tests in the browser
+- Updated node versions to be run on Travis and AppVeyor
+
 ## [4.1.2] - 2016-03-17
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Tests
 Run the test suite by doing:
 
 ```sh
-$ gulp test
+$ npm test
 ```
 
 Contribute

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,8 +11,8 @@ cache:
 # what combinations to test
 environment:
   matrix:
-    - nodejs_version: 0.10
-    - nodejs_version: 0.11
+    - nodejs_version: 6
+    - nodejs_version: 4
     - nodejs_version: 0.12
 
 install:
@@ -25,5 +25,5 @@ build: off
 test_script:
   - node --version
   - npm --version
-  - ps: gulp test
-  - cmd: gulp test
+  - ps: npm test
+  - cmd: npm test

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,6 +17,7 @@ environment:
 
 install:
   - ps: Install-Product node $env:nodejs_version x64
+  - npm install -g npm
   - npm install -g gulp
   - npm install
 

--- a/doc/README.hbs
+++ b/doc/README.hbs
@@ -48,7 +48,7 @@ Tests
 Run the test suite by doing:
 
 ```sh
-$ gulp test
+$ npm test
 ```
 
 Contribute

--- a/karma.conf.coffee
+++ b/karma.conf.coffee
@@ -1,0 +1,10 @@
+karmaConfig = require('resin-config-karma')
+packageJSON = require('./package.json')
+
+module.exports = (config) ->
+	karmaConfig.logLevel = config.LOG_INFO
+	karmaConfig.sauceLabs =
+		testName: "#{packageJSON.name} v#{packageJSON.version}"
+	karmaConfig.client =
+		captureConsole: true
+	config.set(karmaConfig)

--- a/package.json
+++ b/package.json
@@ -17,8 +17,10 @@
     "test": "tests"
   },
   "scripts": {
-    "test": "gulp test",
-    "prepublish": "gulp build",
+    "test": "npm run test-node && npm run test-browser",
+    "test-node": "gulp test",
+    "test-browser": "karma start",
+    "prepublish": "npm test && gulp build",
     "readme": "jsdoc2md --template doc/README.hbs build/request.js > README.md"
   },
   "author": "Juan Cruz Viotti <juanchiviotti@gmail.com>",
@@ -31,9 +33,11 @@
     "gulp-mocha": "^2.2.0",
     "gulp-util": "^3.0.1",
     "jsdoc-to-markdown": "^1.1.1",
+    "karma": "^1.3.0",
     "mocha": "^2.4.5",
     "mochainon": "^1.0.0",
     "nock": "^7.4.0",
+    "resin-config-karma": "^1.0.4",
     "timekeeper": "0.0.5"
   },
   "dependencies": {
@@ -42,7 +46,7 @@
     "progress-stream": "^1.1.1",
     "request": "^2.53.0",
     "resin-errors": "^2.3.0",
-    "resin-token": "^2.4.1",
+    "resin-token": "^2.4.3",
     "rindle": "^1.2.0"
   }
 }


### PR DESCRIPTION
And now finally we have a browser-compatible resin-request module.
It refers to the github version of resin-token, I will update that when the new version is released.