### PR TITLE
Optionally retry requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
-- Added a 'retries' option you can pass to `send()` which sets the number of times to retry failing requests.
+- Added a 'retries' option you can pass to `send()`, to set the number of times to retry
+failing requests, or to `getRequest` directly to set the default number of retries.
 
 ## [6.1.1] - 2016-12-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+### Changed
+
+- Added a 'retries' option you can pass to `send()` which sets the number of times to retry failing requests.
+
 ## [6.1.1] - 2016-12-13
 
 ### Changed

--- a/build/request.js
+++ b/build/request.js
@@ -44,8 +44,8 @@ progress = require('./progress');
 onlyIf = utils.onlyIf;
 
 module.exports = getRequest = function(arg) {
-  var dataDirectory, debug, debugRequest, exports, isBrowser, prepareOptions, ref, ref1, ref2, ref3, token;
-  ref = arg != null ? arg : {}, dataDirectory = (ref1 = ref.dataDirectory) != null ? ref1 : null, debug = (ref2 = ref.debug) != null ? ref2 : false, isBrowser = (ref3 = ref.isBrowser) != null ? ref3 : false;
+  var dataDirectory, debug, debugRequest, exports, isBrowser, prepareOptions, ref, ref1, ref2, ref3, ref4, retries, token;
+  ref = arg != null ? arg : {}, dataDirectory = (ref1 = ref.dataDirectory) != null ? ref1 : null, debug = (ref2 = ref.debug) != null ? ref2 : false, retries = (ref3 = ref.retries) != null ? ref3 : 0, isBrowser = (ref4 = ref.isBrowser) != null ? ref4 : false;
   token = getToken({
     dataDirectory: dataDirectory
   });
@@ -62,7 +62,7 @@ module.exports = getRequest = function(arg) {
       strictSSL: true,
       headers: {},
       refreshToken: true,
-      retries: 0
+      retries: retries
     });
     baseUrl = options.baseUrl;
     if (options.uri) {

--- a/build/request.js
+++ b/build/request.js
@@ -61,7 +61,8 @@ module.exports = getRequest = function(arg) {
       json: true,
       strictSSL: true,
       headers: {},
-      refreshToken: true
+      refreshToken: true,
+      retries: 0
     });
     baseUrl = options.baseUrl;
     if (options.uri) {

--- a/lib/request.coffee
+++ b/lib/request.coffee
@@ -47,6 +47,7 @@ module.exports = getRequest = ({ dataDirectory = null, debug = false, isBrowser 
 			strictSSL: true
 			headers: {}
 			refreshToken: true
+			retries: 0
 
 		{ baseUrl } = options
 

--- a/lib/request.coffee
+++ b/lib/request.coffee
@@ -32,7 +32,7 @@ progress = require('./progress')
 
 { onlyIf } = utils
 
-module.exports = getRequest = ({ dataDirectory = null, debug = false, isBrowser = false } = {}) ->
+module.exports = getRequest = ({ dataDirectory = null, debug = false, retries = 0, isBrowser = false } = {}) ->
 
 	token = getToken({ dataDirectory })
 	debugRequest = if not debug then noop else utils.debugRequest
@@ -47,7 +47,7 @@ module.exports = getRequest = ({ dataDirectory = null, debug = false, isBrowser 
 			strictSSL: true
 			headers: {}
 			refreshToken: true
-			retries: 0
+			retries: retries
 
 		{ baseUrl } = options
 

--- a/tests/request.spec.coffee
+++ b/tests/request.spec.coffee
@@ -263,11 +263,10 @@ describe 'Request:', ->
 					if requestsSeen <= 2
 						Promise.reject(new Error('low-level network error'))
 					else
-						Promise.resolve(
+						Promise.resolve
 							body: result: 'success'
 							headers:
 								'Content-Type': 'application/json'
-						)
 
 			it 'should fail by default', ->
 				promise = request.send

--- a/tests/request.spec.coffee
+++ b/tests/request.spec.coffee
@@ -1,6 +1,6 @@
 m = require('mochainon')
 
-{ token, request, fetchMock } = require('./setup')()
+{ token, request, getCustomRequest, fetchMock } = require('./setup')()
 
 describe 'Request:', ->
 
@@ -290,3 +290,12 @@ describe 'Request:', ->
 					retries: 2
 				.get('body')
 				m.chai.expect(promise).to.eventually.become(result: 'success')
+
+			it 'should retry and eventually succeed if set to retry more than once by default', ->
+				retryingRequest = getCustomRequest({ retries: 2 })
+				promise = retryingRequest.send
+					method: 'GET'
+					url: 'https://example.com/initially-failing'
+				.get('body')
+				m.chai.expect(promise).to.eventually.become(result: 'success')
+

--- a/tests/request.spec.coffee
+++ b/tests/request.spec.coffee
@@ -9,6 +9,9 @@ describe 'Request:', ->
 	beforeEach ->
 		token.remove()
 
+	afterEach ->
+		fetchMock.restore()
+
 	describe '.send()', ->
 
 		describe 'given a simple GET endpoint', ->
@@ -18,9 +21,6 @@ describe 'Request:', ->
 					body: from: 'resin'
 					headers:
 						'Content-Type': 'application/json'
-
-			afterEach ->
-				fetchMock.restore()
 
 			describe 'given an absolute url', ->
 
@@ -72,9 +72,6 @@ describe 'Request:', ->
 					headers:
 						'Content-Type': 'application/json'
 
-			afterEach ->
-				fetchMock.restore()
-
 			it 'should default to GET', ->
 				promise = request.send
 					baseUrl: 'https://api.resin.io'
@@ -86,9 +83,6 @@ describe 'Request:', ->
 
 			beforeEach ->
 				fetchMock.get('https://api.resin.io/foo', 'Hello World')
-
-			afterEach ->
-				fetchMock.restore()
 
 			it 'should resolve with the plain body', ->
 				promise = request.send
@@ -103,9 +97,6 @@ describe 'Request:', ->
 			beforeEach ->
 				fetchMock.post 'https://api.resin.io/foo', (url, opts) ->
 					return "The body is: #{opts.body}"
-
-			afterEach ->
-				fetchMock.restore()
 
 			it 'should take the plain body successfully', ->
 				promise = request.send
@@ -129,9 +120,6 @@ describe 'Request:', ->
 							headers:
 								'Content-Type': 'application/json'
 
-					afterEach ->
-						fetchMock.restore()
-
 					it 'should correctly make the request', ->
 						promise = request.send
 							method: 'GET'
@@ -148,9 +136,6 @@ describe 'Request:', ->
 							body: error: text: 'Server Error'
 							headers:
 								'Content-Type': 'application/json'
-
-					afterEach ->
-						fetchMock.restore()
 
 					it 'should be rejected with the error message', ->
 						promise = request.send
@@ -174,9 +159,6 @@ describe 'Request:', ->
 					beforeEach ->
 						fetchMock.head('https://api.resin.io/foo', 200)
 
-					afterEach ->
-						fetchMock.restore()
-
 					it 'should correctly make the request', ->
 						promise = request.send
 							method: 'HEAD'
@@ -189,9 +171,6 @@ describe 'Request:', ->
 
 					beforeEach ->
 						fetchMock.head('https://api.resin.io/foo', 500)
-
-					afterEach ->
-						fetchMock.restore()
 
 					it 'should be rejected with a generic error message', ->
 						promise = request.send
@@ -211,9 +190,6 @@ describe 'Request:', ->
 						headers:
 							'Content-Type': 'application/json'
 
-				afterEach ->
-					fetchMock.restore()
-
 				it 'should eventually return the body', ->
 					promise = request.send
 						method: 'POST'
@@ -231,9 +207,6 @@ describe 'Request:', ->
 						body: opts.body
 						headers:
 							'Content-Type': 'application/json'
-
-				afterEach ->
-					fetchMock.restore()
 
 				it 'should eventually return the body', ->
 					promise = request.send
@@ -253,9 +226,6 @@ describe 'Request:', ->
 						headers:
 							'Content-Type': 'application/json'
 
-				afterEach ->
-					fetchMock.restore()
-
 				it 'should eventually return the body', ->
 					promise = request.send
 						method: 'PATCH'
@@ -273,9 +243,6 @@ describe 'Request:', ->
 						body: opts.body
 						headers:
 							'Content-Type': 'application/json'
-
-				afterEach ->
-					fetchMock.restore()
 
 				it 'should eventually return the body', ->
 					promise = request.send

--- a/tests/setup.coffee
+++ b/tests/setup.coffee
@@ -19,8 +19,13 @@ if not IS_BROWSER
 	settings = require('resin-settings-client')
 	dataDirectory = settings.get('dataDirectory')
 
+getCustomRequest = (opts) ->
+	opts = _.assign({}, opts, { dataDirectory, debug: false, isBrowser: IS_BROWSER })
+	getRequest(opts)
+
 module.exports = ->
 	IS_BROWSER: IS_BROWSER
 	fetchMock: fetchMock
 	token: getToken({ dataDirectory })
-	request: getRequest({ dataDirectory, debug: false, isBrowser: IS_BROWSER })
+	request: getCustomRequest()
+	getCustomRequest: getCustomRequest


### PR DESCRIPTION
Adds a 'retries' option you can pass to `send()`, which sets the number of times to retry this request (defaulting to 0).

This is part of the fix for resin-io/resin-sdk#237.