### PR TITLE
Track request time and include it in output when debug mode is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+- Include 'duration' in debug output, if enabled
 - Added a 'retries' option you can pass to `send()`, to set the number of times to retry
 failing requests, or to `getRequest` directly to set the default number of retries.
 

--- a/build/utils.js
+++ b/build/utils.js
@@ -195,7 +195,8 @@ exports.getResponseLength = function(response) {
 
 exports.debugRequest = function(options, response) {
   return console.error(assign({
-    statusCode: response.statusCode
+    statusCode: response.statusCode,
+    duration: response.duration
   }, options));
 };
 
@@ -304,7 +305,7 @@ timeoutPromise = function(ms, promise) {
  */
 
 exports.requestAsync = function(options, retriesRemaining) {
-  var opts, p, ref, timeout, url;
+  var opts, p, ref, requestTime, timeout, url;
   if (retriesRemaining == null) {
     retriesRemaining = void 0;
   }
@@ -314,11 +315,15 @@ exports.requestAsync = function(options, retriesRemaining) {
   }
   timeout = opts.timeout;
   delete opts.timeout;
+  requestTime = new Date();
   p = fetch(url, opts);
   if (timeout) {
     p = timeoutPromise(timeout, p);
   }
   return p.then(function(response) {
+    var responseTime;
+    responseTime = new Date();
+    response.duration = responseTime - requestTime;
     response.statusCode = response.status;
     response.request = {
       headers: options.headers,

--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -163,7 +163,10 @@ exports.getResponseLength = (response) ->
 # 	utils.debugRequest(options, response)
 ###
 exports.debugRequest = (options, response) ->
-	console.error(assign({ statusCode: response.statusCode }, options))
+	console.error(assign(
+		statusCode: response.statusCode
+		duration: response.duration
+	, options))
 
 # fetch adapter
 
@@ -299,11 +302,14 @@ exports.requestAsync = (options, retriesRemaining = undefined) ->
 	{ timeout } = opts
 	delete opts.timeout
 
+	requestTime = new Date()
 	p = fetch(url, opts)
 	if timeout
 		p = timeoutPromise(timeout, p)
 
 	return p.then (response) ->
+		responseTime = new Date()
+		response.duration = responseTime - requestTime
 		response.statusCode = response.status
 		response.request =
 			headers: options.headers


### PR DESCRIPTION
Nice simple one: just adds 'duration' to the log output, so that for resin-io/resin-sdk#237 we can easily start examining how long requests are actually taking.