### PR TITLE
Use fetch-ponyfill instead of requiring isomorphic-fetch downstream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 
 - Timeouts in requests now use the Bluebird implementation. This changes how errors are thrown slightly: a `Promise.TimeoutError` is now thrown instead of a raw `Error`, with the message "operation timed out" instead of "timeout".
+- Fetch is now provided internally (by `Fetch-ponyfill`), so isomorphic-fetch is no longer required in downstream applications.
 
 ## [6.2.0] - 2016-12-13
 

--- a/README.md
+++ b/README.md
@@ -30,11 +30,6 @@ $ npm install --save resin-request
 Documentation
 -------------
 
-**Note.** This module expects [`fetch`](https://developer.mozilla.org/en/docs/Web/API/Fetch_API)
-and [`Promise`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)
-to be available in the global scope.
-The easiest way to get `fetch` is to use `isomorphic-fetch` npm module.
-
 The module returns a _factory function_ that you use to get an instance of the token module.
 
 It accepts the following params:

--- a/build/utils.js
+++ b/build/utils.js
@@ -15,9 +15,13 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
  */
-var Promise, UNSUPPORTED_REQUEST_PARAMS, assign, includes, notImplemented, parseInt, processBody, processRequestOptions, qs, urlLib;
+var Headers, Promise, UNSUPPORTED_REQUEST_PARAMS, assign, fetch, includes, notImplemented, parseInt, processBody, processRequestOptions, qs, ref, urlLib;
 
 Promise = require('bluebird');
+
+ref = require('fetch-ponyfill')({
+  Promise: Promise
+}), fetch = ref.fetch, Headers = ref.Headers;
 
 urlLib = require('url');
 
@@ -33,6 +37,8 @@ includes = require('lodash/includes');
 /**
  * @module utils
  */
+
+exports.fetch = fetch;
 
 exports.TOKEN_REFRESH_INTERVAL = 1 * 1000 * 60 * 60;
 
@@ -294,15 +300,15 @@ exports.getBody = processBody = function(response) {
  */
 
 exports.requestAsync = function(options, retriesRemaining) {
-  var opts, p, ref, requestTime, timeout, url;
-  ref = processRequestOptions(options), url = ref[0], opts = ref[1];
+  var opts, p, ref1, requestTime, timeout, url;
+  ref1 = processRequestOptions(options), url = ref1[0], opts = ref1[1];
   if (retriesRemaining == null) {
     retriesRemaining = opts.retries;
   }
   timeout = opts.timeout;
   delete opts.timeout;
   requestTime = new Date();
-  p = fetch(url, opts);
+  p = exports.fetch(url, opts);
   if (timeout) {
     p = p.timeout(timeout);
   }

--- a/doc/README.hbs
+++ b/doc/README.hbs
@@ -30,11 +30,6 @@ $ npm install --save resin-request
 Documentation
 -------------
 
-**Note.** This module expects [`fetch`](https://developer.mozilla.org/en/docs/Web/API/Fetch_API)
-and [`Promise`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)
-to be available in the global scope.
-The easiest way to get `fetch` is to use `isomorphic-fetch` npm module.
-
 The module returns a _factory function_ that you use to get an instance of the token module.
 
 It accepts the following params:

--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -15,6 +15,7 @@ limitations under the License.
 ###
 
 Promise = require('bluebird')
+{ fetch, Headers } = require('fetch-ponyfill')({ Promise })
 urlLib = require('url')
 qs = require('qs')
 parseInt = require('lodash/parseInt')
@@ -26,6 +27,7 @@ includes = require('lodash/includes')
 ###
 
 # Expose for testing purposes
+exports.fetch = fetch
 exports.TOKEN_REFRESH_INTERVAL = 1 * 1000 * 60 * 60 # 1 hour in milliseconds
 
 ###*
@@ -293,7 +295,7 @@ exports.requestAsync = (options, retriesRemaining) ->
 	delete opts.timeout
 
 	requestTime = new Date()
-	p = fetch(url, opts)
+	p = exports.fetch(url, opts)
 	if timeout
 		p = p.timeout(timeout)
 

--- a/package.json
+++ b/package.json
@@ -29,13 +29,12 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "coffee-script": "~1.12.1",
-    "fetch-mock": "^5.1.5",
+    "fetch-mock": "^5.8.0",
     "gulp": "^3.9.1",
     "gulp-coffee": "^2.3.1",
     "gulp-coffeelint": "^0.6.0",
     "gulp-mocha": "^3.0.0",
     "gulp-util": "^3.0.1",
-    "isomorphic-fetch": "^2.2.1",
     "jsdoc-to-markdown": "^2.0.1",
     "karma": "^1.3.0",
     "mocha": "^3.0.0",
@@ -46,6 +45,7 @@
   },
   "dependencies": {
     "bluebird": "^3.3.4",
+    "fetch-ponyfill": "^3.0.2",
     "lodash": "^4.6.1",
     "progress-stream": "^1.1.1",
     "qs": "^6.3.0",

--- a/tests/api-key.spec.coffee
+++ b/tests/api-key.spec.coffee
@@ -22,7 +22,7 @@ describe 'Request (api key):', ->
 		describe 'given a simple GET endpoint containing special characters in query strings', ->
 
 			beforeEach ->
-				fetchMock.get('^https://api.resin.io/foo', 200)
+				fetchMock.get('begin:https://api.resin.io/foo', 200)
 
 			afterEach ->
 				fetchMock.restore()
@@ -56,7 +56,7 @@ describe 'Request (api key):', ->
 		describe 'given a simple GET endpoint', ->
 
 			beforeEach ->
-				fetchMock.get('^https://api.resin.io/foo', 'Foo Bar')
+				fetchMock.get('begin:https://api.resin.io/foo', 'Foo Bar')
 
 			afterEach ->
 				fetchMock.restore()

--- a/tests/api-key.spec.coffee
+++ b/tests/api-key.spec.coffee
@@ -169,17 +169,6 @@ describe 'Request (api key):', ->
 							.get('query')
 							m.chai.expect(promise).to.eventually.be.null
 
-						it 'should not pass an apikey query string', ->
-							promise = request.send
-								method: 'GET'
-								baseUrl: 'https://api.resin.io'
-								url: '/foo'
-								apiKey: ''
-							.get('request')
-							.get('uri')
-							.get('query')
-							m.chai.expect(promise).to.eventually.be.null
-
 					describe '.stream()', ->
 
 						return if IS_BROWSER

--- a/tests/request.spec.coffee
+++ b/tests/request.spec.coffee
@@ -1,3 +1,4 @@
+Promise = require('bluebird')
 m = require('mochainon')
 
 { token, request, getCustomRequest, fetchMock } = require('./setup')()
@@ -14,39 +15,28 @@ describe 'Request:', ->
 
 	describe '.send()', ->
 
-		describe 'given a simple GET endpoint', ->
+		describe 'given a simple absolute GET endpoint', ->
 
 			beforeEach ->
-				fetchMock.get 'https://api.resin.io/foo',
-					body: from: 'resin'
+				fetchMock.get 'https://foobar.baz/foo',
+					body: from: 'foobar'
 					headers:
 						'Content-Type': 'application/json'
 
-			describe 'given an absolute url', ->
+			it 'should preserve the absolute url', ->
+				promise = request.send
+					method: 'GET'
+					url: 'https://foobar.baz/foo'
+				.get('body')
+				m.chai.expect(promise).to.eventually.become(from: 'foobar')
 
-				beforeEach ->
-					fetchMock.get 'https://foobar.baz/foo',
-						body: from: 'foobar'
-						headers:
-							'Content-Type': 'application/json'
-
-				afterEach ->
-					fetchMock.restore()
-
-				it 'should preserve the absolute url', ->
-					promise = request.send
-						method: 'GET'
-						url: 'https://foobar.baz/foo'
-					.get('body')
-					m.chai.expect(promise).to.eventually.become(from: 'foobar')
-
-				it 'should allow passing a baseUrl', ->
-					promise = request.send
-						method: 'GET'
-						baseUrl: 'https://foobar.baz'
-						url: '/foo'
-					.get('body')
-					m.chai.expect(promise).to.eventually.become(from: 'foobar')
+			it 'should allow passing a baseUrl', ->
+				promise = request.send
+					method: 'GET'
+					baseUrl: 'https://foobar.baz'
+					url: '/foo'
+				.get('body')
+				m.chai.expect(promise).to.eventually.become(from: 'foobar')
 
 		describe 'given multiple endpoints', ->
 

--- a/tests/setup.coffee
+++ b/tests/setup.coffee
@@ -5,19 +5,24 @@ IS_BROWSER = window?
 
 if (IS_BROWSER)
 	# The browser mock assumes global fetch prototypes exist
+	# Can improve after https://github.com/wheresrhys/fetch-mock/issues/158
 	realFetchModule = require('fetch-ponyfill')({ Promise })
-	global.Promise = Promise
 	global.Headers = realFetchModule.Headers
 	global.Request = realFetchModule.Request
 	global.Response = realFetchModule.Response
 
 fetchMock = require('fetch-mock').sandbox(Promise)
+
+# Promise sandbox config needs a little help. See:
+# https://github.com/wheresrhys/fetch-mock/issues/159#issuecomment-268249788
 fetchMock.fetchMock.Promise = Promise
+
 fetchMock.patch = (matcher, response, options) ->
 	options = _.assign({}, options, { method: 'PATCH' })
 	@mock(matcher, response, options)
 
 utils = require('../lib/utils')
+# Can probably just be 'fetchMock' after https://github.com/wheresrhys/fetch-mock/issues/159
 utils.fetch = fetchMock.fetchMock
 
 getToken = require('resin-token')

--- a/tests/setup.coffee
+++ b/tests/setup.coffee
@@ -12,6 +12,7 @@ if (IS_BROWSER)
 	global.Response = realFetchModule.Response
 
 fetchMock = require('fetch-mock').sandbox(Promise)
+fetchMock.fetchMock.Promise = Promise
 fetchMock.patch = (matcher, response, options) ->
 	options = _.assign({}, options, { method: 'PATCH' })
 	@mock(matcher, response, options)

--- a/tests/setup.coffee
+++ b/tests/setup.coffee
@@ -1,18 +1,26 @@
-Promise = require('bluebird')
-global.Promise = Promise
-require('isomorphic-fetch')
-
 _ = require('lodash')
+Promise = require('bluebird')
 
-fetchMock = require('fetch-mock')
+IS_BROWSER = window?
+
+if (IS_BROWSER)
+	# The browser mock assumes global fetch prototypes exist
+	realFetchModule = require('fetch-ponyfill')({ Promise })
+	global.Promise = Promise
+	global.Headers = realFetchModule.Headers
+	global.Request = realFetchModule.Request
+	global.Response = realFetchModule.Response
+
+fetchMock = require('fetch-mock').sandbox(Promise)
 fetchMock.patch = (matcher, response, options) ->
 	options = _.assign({}, options, { method: 'PATCH' })
 	@mock(matcher, response, options)
 
+utils = require('../lib/utils')
+utils.fetch = fetchMock.fetchMock
+
 getToken = require('resin-token')
 getRequest = require('../lib/request')
-
-IS_BROWSER = window?
 
 dataDirectory = null
 if not IS_BROWSER

--- a/tests/setup.coffee
+++ b/tests/setup.coffee
@@ -3,13 +3,11 @@ Promise = require('bluebird')
 
 IS_BROWSER = window?
 
-if (IS_BROWSER)
+if IS_BROWSER
 	# The browser mock assumes global fetch prototypes exist
 	# Can improve after https://github.com/wheresrhys/fetch-mock/issues/158
 	realFetchModule = require('fetch-ponyfill')({ Promise })
-	global.Headers = realFetchModule.Headers
-	global.Request = realFetchModule.Request
-	global.Response = realFetchModule.Response
+	_.assign(global, _.pick(realFetchModule, 'Headers', 'Request', 'Response'))
 
 fetchMock = require('fetch-mock').sandbox(Promise)
 

--- a/tests/token.spec.coffee
+++ b/tests/token.spec.coffee
@@ -19,7 +19,7 @@ describe 'Request (token):', ->
 		describe 'given a simple GET endpoint', ->
 
 			beforeEach ->
-				fetchMock.get('^https://api.resin.io/foo', 'bar')
+				fetchMock.get('begin:https://api.resin.io/foo', 'bar')
 
 			afterEach ->
 				fetchMock.restore()

--- a/tests/utils.spec.coffee
+++ b/tests/utils.spec.coffee
@@ -1,5 +1,6 @@
 ReadableStream = require('stream').Readable
 Promise = require('bluebird')
+{ Headers } = require('fetch-ponyfill')({ Promise })
 m = require('mochainon')
 johnDoeFixture = require('./tokens.json').johndoe
 utils = require('../lib/utils')


### PR DESCRIPTION
This ended up being drastically harder than the equivalent register-resin-device change (see https://github.com/resin-io-modules/resin-register-device/pull/27), but it's now all working. Some caveats:

* There's quite a few workarounds for various `fetch-mock` issues, leading to some remaining strange and wonderful setup code for that in `setup.coffee`. Everything elsewhere comes out nicely though, and I've filed a couple of issues and linked them inline, so we can improve this later as they get solved.

* Mockery works fine in Node, but getting any mocking working in Browserify without breaking Node  became a huge pain, and I've opted for the far simpler option: exposing `utils.fetch`, and letting you change it externally. Less elegant, and I'd welcome an improvement on that if anybody has an easy one, but I spent quite a while fighting with `proxyquirify-universal` and even the bits that worked leave you with a big mess.

I've given this a quick test in resin-sdk, dropping it in and taking isomorphic-fetch out seems to work perfectly.