### PR TITLE
Fix broken timeout functionality, and cancel underlying requests where possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+### Changed
+
+- Fixed bug where no timeouts were set
+- Timeouts now abort underlying requests (in Node only)
+
 ## [7.0.0] - 2017-01-02
 
 ### Changed

--- a/build/utils.js
+++ b/build/utils.js
@@ -15,13 +15,13 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
  */
-var Headers, IS_BROWSER, Promise, UNSUPPORTED_REQUEST_PARAMS, assign, fetch, includes, notImplemented, parseInt, processBody, processRequestOptions, qs, ref, urlLib;
+var Headers, IS_BROWSER, Promise, UNSUPPORTED_REQUEST_PARAMS, _fetch, assign, includes, notImplemented, parseInt, processBody, processRequestOptions, qs, ref, urlLib;
 
 Promise = require('bluebird');
 
 ref = require('fetch-ponyfill')({
   Promise: Promise
-}), fetch = ref.fetch, Headers = ref.Headers;
+}), _fetch = ref._fetch, Headers = ref.Headers;
 
 urlLib = require('url');
 
@@ -40,7 +40,7 @@ IS_BROWSER = typeof window !== "undefined" && window !== null;
  * @module utils
  */
 
-exports.fetch = fetch;
+exports.fetch = _fetch;
 
 exports.TOKEN_REFRESH_INTERVAL = 1 * 1000 * 60 * 60;
 

--- a/build/utils.js
+++ b/build/utils.js
@@ -15,7 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
  */
-var Headers, Promise, UNSUPPORTED_REQUEST_PARAMS, assign, fetch, includes, notImplemented, parseInt, processBody, processRequestOptions, qs, ref, urlLib;
+var Headers, IS_BROWSER, Promise, UNSUPPORTED_REQUEST_PARAMS, assign, fetch, includes, notImplemented, parseInt, processBody, processRequestOptions, qs, ref, urlLib;
 
 Promise = require('bluebird');
 
@@ -32,6 +32,8 @@ parseInt = require('lodash/parseInt');
 assign = require('lodash/assign');
 
 includes = require('lodash/includes');
+
+IS_BROWSER = typeof window !== "undefined" && window !== null;
 
 
 /**
@@ -222,6 +224,7 @@ processRequestOptions = function(options) {
     url += (url.indexOf('?') >= 0 ? '&' : '?') + params;
   }
   opts = {};
+  opts.timeout = options.timeout;
   opts.retries = options.retries;
   opts.method = options.method;
   opts.compress = options.gzip;
@@ -300,17 +303,15 @@ exports.getBody = processBody = function(response) {
  */
 
 exports.requestAsync = function(options, retriesRemaining) {
-  var opts, p, ref1, requestTime, timeout, url;
+  var opts, p, ref1, requestTime, url;
   ref1 = processRequestOptions(options), url = ref1[0], opts = ref1[1];
   if (retriesRemaining == null) {
     retriesRemaining = opts.retries;
   }
-  timeout = opts.timeout;
-  delete opts.timeout;
   requestTime = new Date();
   p = exports.fetch(url, opts);
-  if (timeout) {
-    p = p.timeout(timeout);
+  if (opts.timeout && IS_BROWSER) {
+    p = p.timeout(opts.timeout);
   }
   p = p.then(function(response) {
     var responseTime;

--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -22,6 +22,8 @@ parseInt = require('lodash/parseInt')
 assign = require('lodash/assign')
 includes = require('lodash/includes')
 
+IS_BROWSER = window?
+
 ###*
 # @module utils
 ###
@@ -216,6 +218,7 @@ processRequestOptions = (options = {}) ->
 
 	opts = {}
 
+	opts.timeout = options.timeout
 	opts.retries = options.retries
 	opts.method = options.method
 	opts.compress = options.gzip
@@ -291,13 +294,11 @@ exports.getBody = processBody = (response) ->
 exports.requestAsync = (options, retriesRemaining) ->
 	[ url, opts ] = processRequestOptions(options)
 	retriesRemaining ?= opts.retries
-	{ timeout } = opts
-	delete opts.timeout
 
 	requestTime = new Date()
 	p = exports.fetch(url, opts)
-	if timeout
-		p = p.timeout(timeout)
+	if opts.timeout and IS_BROWSER
+		p = p.timeout(opts.timeout)
 
 	p = p.then (response) ->
 		responseTime = new Date()

--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -15,7 +15,8 @@ limitations under the License.
 ###
 
 Promise = require('bluebird')
-{ fetch, Headers } = require('fetch-ponyfill')({ Promise })
+# _ prefixed because exports.fetch should always be used instead.
+{ _fetch, Headers } = require('fetch-ponyfill')({ Promise })
 urlLib = require('url')
 qs = require('qs')
 parseInt = require('lodash/parseInt')
@@ -28,8 +29,8 @@ IS_BROWSER = window?
 # @module utils
 ###
 
-# Expose for testing purposes
-exports.fetch = fetch
+# Expose for testing purposes.
+exports.fetch = _fetch
 exports.TOKEN_REFRESH_INTERVAL = 1 * 1000 * 60 * 60 # 1 hour in milliseconds
 
 ###*

--- a/tests/request.spec.coffee
+++ b/tests/request.spec.coffee
@@ -309,7 +309,8 @@ describe 'Request:', ->
 					if not IS_BROWSER and opts.timeout
 						Promise.delay(opts.timeout).throw(NODE_TIMEOUT_ERROR)
 					# Browser/no timeout fetch() simply never resolves.
-					else new Promise(_.noop)
+					else
+						new Promise(_.noop)
 
 			it 'should reject the promise after 30s by default', ->
 				promise = request.send

--- a/tests/request.spec.coffee
+++ b/tests/request.spec.coffee
@@ -1,3 +1,4 @@
+_ = require('lodash')
 Promise = require('bluebird')
 m = require('mochainon')
 
@@ -306,10 +307,9 @@ describe 'Request:', ->
 
 					# Emulate node-fetch timeout behaviour if we use it
 					if not IS_BROWSER and opts.timeout
-						new Promise (resolve, reject) ->
-							setTimeout((-> reject(NODE_TIMEOUT_ERROR)), opts.timeout)
+						Promise.delay(opts.timeout).throw(NODE_TIMEOUT_ERROR)
 					# Browser/no timeout fetch() simply never resolves.
-					else new Promise(->)
+					else new Promise(_.noop)
 
 			it 'should reject the promise after 30s by default', ->
 				promise = request.send

--- a/tests/request.spec.coffee
+++ b/tests/request.spec.coffee
@@ -1,7 +1,7 @@
 Promise = require('bluebird')
 m = require('mochainon')
 
-{ token, request, getCustomRequest, fetchMock } = require('./setup')()
+{ token, request, getCustomRequest, fetchMock, IS_BROWSER } = require('./setup')()
 
 describe 'Request:', ->
 
@@ -290,3 +290,64 @@ describe 'Request:', ->
 				.get('body')
 				m.chai.expect(promise).to.eventually.become(result: 'success')
 
+		describe 'given an endpoint that will time out', ->
+
+			NODE_TIMEOUT_ERROR = new Error('node timeout error')
+
+			beforeEach ->
+				@clock = m.sinon.useFakeTimers()
+
+			afterEach ->
+				@clock.restore()
+
+			stubTimeout = -> new Promise (resolve, reject) ->
+				fetchMock.get 'http://infinite-wait.com', (url, opts) ->
+					resolve()
+
+					# Emulate node-fetch timeout behaviour if we use it
+					if not IS_BROWSER and opts.timeout
+						new Promise (resolve, reject) ->
+							setTimeout((-> reject(NODE_TIMEOUT_ERROR)), opts.timeout)
+					# Browser/no timeout fetch() simply never resolves.
+					else new Promise(->)
+
+			it 'should reject the promise after 30s by default', ->
+				promise = request.send
+					method: 'GET'
+					url: 'http://infinite-wait.com'
+				.get('body')
+
+				stubTimeout().then =>
+					@clock.tick(29000)
+					m.chai.expect(promise.isPending()).to.equal(true)
+
+					@clock.tick(1000)
+					m.chai.expect(promise).to.eventually.be.rejectedWith(Error)
+
+			it 'should use a provided timeout option', ->
+				promise = request.send
+					method: 'GET'
+					url: 'http://infinite-wait.com'
+					timeout: 5000
+				.get('body')
+
+				stubTimeout().then =>
+					@clock.tick(4000)
+					m.chai.expect(promise.isPending()).to.equal(true)
+
+					@clock.tick(1000)
+					m.chai.expect(promise).to.eventually.be.rejectedWith(Error)
+
+			it 'should be rejected by the correct error', ->
+				promise = request.send
+					method: 'GET'
+					url: 'http://infinite-wait.com'
+				.get('body')
+
+				stubTimeout().then =>
+					@clock.tick(30000)
+
+					if IS_BROWSER
+						m.chai.expect(promise).to.be.rejectedWith(Promise.TimeoutError)
+					else
+						m.chai.expect(promise).to.be.rejectedWith(NODE_TIMEOUT_ERROR)


### PR DESCRIPTION
This fixes #83.

When I added the tests for this, I noticed that somewhere along the way we've actually broken timeouts in resin-request completely. The default 30s timeout is ignored, and any manually passed timeout options are ignored, because we drop them in `processRequestOptions`.

This patch fixes that. It also now passes the `timeout` option to the fetch call (so that `node-fetch` [forcefully cancels the underlying request](https://github.com/bitinn/node-fetch/blob/3c053ce32760d2d5d6cb8712fb4115b44e4083d4/index.js#L125)) and only sets the extra bluebird non-canceling timeout if you're in a browser (where fetch can't be cancelled).