### PR TITLE
Move to a DI approach for resin-token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+- **Breaking:** Resin-Token must now be injected, rather than being built internally
 - Fixed bug where no timeouts were set
 - Timeouts now abort underlying requests (in Node only)
 

--- a/README.md
+++ b/README.md
@@ -37,14 +37,14 @@ It accepts the following params:
 | Param | Type | Description |
 | --- | --- | --- |
 | options | <code>Object</code> | options |
-| options.dataDirectory | <code>string</code> | the directory to use for token storage in Node.js. Ignored in the browser. |
+| options.token | <code>Object</code> | An instantiated [resin-token](https://github.com/resin-io/resin-token) instance |
 | options.debug | <code>boolean</code> | when set to `true` will log the request details in case of error. |
 | options.isBrowser | <code>boolean</code> | set to `true` if the runtime is the browser. |
 
 **Example**
 ```js
 var request = require('resin-request')({
-	dataDirectory: '/opt/cache/resin',
+	token: token,
 	debug: false,
 	isBrowser: false
 })

--- a/build/request.js
+++ b/build/request.js
@@ -44,11 +44,8 @@ progress = require('./progress');
 onlyIf = utils.onlyIf;
 
 module.exports = getRequest = function(arg) {
-  var dataDirectory, debug, debugRequest, exports, isBrowser, prepareOptions, ref, ref1, ref2, ref3, ref4, retries, token;
-  ref = arg != null ? arg : {}, dataDirectory = (ref1 = ref.dataDirectory) != null ? ref1 : null, debug = (ref2 = ref.debug) != null ? ref2 : false, retries = (ref3 = ref.retries) != null ? ref3 : 0, isBrowser = (ref4 = ref.isBrowser) != null ? ref4 : false;
-  token = getToken({
-    dataDirectory: dataDirectory
-  });
+  var debug, debugRequest, exports, isBrowser, prepareOptions, ref, ref1, ref2, ref3, retries, token;
+  ref = arg != null ? arg : {}, token = ref.token, debug = (ref1 = ref.debug) != null ? ref1 : false, retries = (ref2 = ref.retries) != null ? ref2 : 0, isBrowser = (ref3 = ref.isBrowser) != null ? ref3 : false;
   debugRequest = !debug ? noop : utils.debugRequest;
   exports = {};
   prepareOptions = function(options) {

--- a/doc/README.hbs
+++ b/doc/README.hbs
@@ -37,14 +37,14 @@ It accepts the following params:
 | Param | Type | Description |
 | --- | --- | --- |
 | options | <code>Object</code> | options |
-| options.dataDirectory | <code>string</code> | the directory to use for token storage in Node.js. Ignored in the browser. |
+| options.token | <code>Object</code> | An instantiated [resin-token](https://github.com/resin-io/resin-token) instance |
 | options.debug | <code>boolean</code> | when set to `true` will log the request details in case of error. |
 | options.isBrowser | <code>boolean</code> | set to `true` if the runtime is the browser. |
 
 **Example**
 ```js
 var request = require('resin-request')({
-	dataDirectory: '/opt/cache/resin',
+	token: token,
 	debug: false,
 	isBrowser: false
 })

--- a/lib/request.coffee
+++ b/lib/request.coffee
@@ -32,9 +32,7 @@ progress = require('./progress')
 
 { onlyIf } = utils
 
-module.exports = getRequest = ({ dataDirectory = null, debug = false, retries = 0, isBrowser = false } = {}) ->
-
-	token = getToken({ dataDirectory })
+module.exports = getRequest = ({ token, debug = false, retries = 0, isBrowser = false } = {}) ->
 	debugRequest = if not debug then noop else utils.debugRequest
 
 	exports = {}

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "mocha": "^3.0.0",
     "mochainon": "^1.0.0",
     "resin-config-karma": "^1.0.4",
-    "resin-settings-client": "^3.5.2",
+    "resin-token": "^3.0.0",
+    "temp": "^0.8.3",
     "timekeeper": "^1.0.0"
   },
   "dependencies": {
@@ -50,7 +51,9 @@
     "progress-stream": "^1.1.1",
     "qs": "^6.3.0",
     "resin-errors": "^2.3.0",
-    "resin-token": "^3.0.0",
     "rindle": "^1.2.0"
+  },
+  "peerDependencies": {
+    "resin-token": "^3.0.0"
   }
 }

--- a/tests/setup.coffee
+++ b/tests/setup.coffee
@@ -23,21 +23,21 @@ utils = require('../lib/utils')
 # Can probably just be 'fetchMock' after https://github.com/wheresrhys/fetch-mock/issues/159
 utils.fetch = fetchMock.fetchMock
 
-getToken = require('resin-token')
-getRequest = require('../lib/request')
-
 dataDirectory = null
 if not IS_BROWSER
-	settings = require('resin-settings-client')
-	dataDirectory = settings.get('dataDirectory')
+	temp = require('temp').track()
+	dataDirectory = temp.mkdirSync()
+
+token = require('resin-token')({ dataDirectory })
+getRequest = require('../lib/request')
 
 getCustomRequest = (opts) ->
-	opts = _.assign({}, opts, { dataDirectory, debug: false, isBrowser: IS_BROWSER })
+	opts = _.assign({}, opts, { token, debug: false, isBrowser: IS_BROWSER })
 	getRequest(opts)
 
 module.exports = ->
 	IS_BROWSER: IS_BROWSER
 	fetchMock: fetchMock
-	token: getToken({ dataDirectory })
+	token: token
 	request: getCustomRequest()
 	getCustomRequest: getCustomRequest


### PR DESCRIPTION
This moves Resin-Request to DI, as discussed in resin-io-modules/resin-request#85