### PR TITLE
Fix tiny bug that breaks everything, except in the tests

### DIFF
--- a/build/utils.js
+++ b/build/utils.js
@@ -21,7 +21,7 @@ Promise = require('bluebird');
 
 ref = require('fetch-ponyfill')({
   Promise: Promise
-}), _fetch = ref._fetch, Headers = ref.Headers;
+}), _fetch = ref.fetch, Headers = ref.Headers;
 
 urlLib = require('url');
 

--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -16,7 +16,7 @@ limitations under the License.
 
 Promise = require('bluebird')
 # _ prefixed because exports.fetch should always be used instead.
-{ _fetch, Headers } = require('fetch-ponyfill')({ Promise })
+{ fetch: _fetch, Headers } = require('fetch-ponyfill')({ Promise })
 urlLib = require('url')
 qs = require('qs')
 parseInt = require('lodash/parseInt')


### PR DESCRIPTION
Having put out 8.0.0 and integrated it everywhere, when I finally got to the SDK where the tests actually use it to make real requests, it doesn't actually work at all.

That tiny _ prefixing fix from yesterday means the fetch-ponyfill import doesn't actually work at all any more, and exports.fetch is always `undefined`. That issue gets completely hidden by the tests, since they always replace it anyway.

Now fixed. I've manually pulled this version into my Resin-SDK locally too, and it seems to now work nicely. Once somebody approves, I'll merge this, deprecate 8.0.0, and put out an 8.0.1 that actually works.