### PR TITLE
Don't try to automatically add an 'accept-encoding' header in the browser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+- Don't add `accept-encoding` in browsers by default (since it doesn't work)
+
 ## [8.2.0] - 2017-02-20
 
 - Added request interception support.

--- a/build/utils.js
+++ b/build/utils.js
@@ -248,7 +248,9 @@ processRequestOptions = function(options) {
     headers['Content-Type'] = 'application/json';
   }
   opts.body = body;
-  headers['Accept-Encoding'] || (headers['Accept-Encoding'] = 'compress, gzip');
+  if (!IS_BROWSER) {
+    headers['Accept-Encoding'] || (headers['Accept-Encoding'] = 'compress, gzip');
+  }
   if (options.followRedirect) {
     opts.redirect = 'follow';
   }

--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -238,7 +238,8 @@ processRequestOptions = (options = {}) ->
 
 	opts.body = body
 
-	headers['Accept-Encoding'] or= 'compress, gzip'
+	if not IS_BROWSER
+		headers['Accept-Encoding'] or= 'compress, gzip'
 
 	if options.followRedirect
 		opts.redirect = 'follow'


### PR DESCRIPTION
Outside the browser this is correct, but in a browser the encoding process is outside our control, and the browser just ignores it and logs a warning:

> Refused to set unsafe header "accept-encoding"

This would be a breaking change if the original code had any effect, but since [the spec](https://fetch.spec.whatwg.org/#forbidden-header-name) says all browsers must ignore it, it's just a patch.