### PR TITLE
Include request options in request errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+- Include request config in errors from failed requests
 - Don't add `accept-encoding` in browsers by default (since it doesn't work)
 
 ## [8.2.0] - 2017-02-20

--- a/lib/request.coffee
+++ b/lib/request.coffee
@@ -179,7 +179,11 @@ module.exports = getRequest = ({
 
 		prepareOptions(options)
 		.then(interceptRequestOptions, interceptRequestError)
-		.then(utils.requestAsync)
+		.then (options) ->
+			utils.requestAsync(options)
+			.catch (error) ->
+				error.requestOptions = options
+				throw error
 		.then (response) ->
 			utils.getBody(response)
 			.then (body) ->
@@ -188,7 +192,7 @@ module.exports = getRequest = ({
 				if utils.isErrorCode(response.statusCode)
 					responseError = utils.getErrorMessageFromResponse(response)
 					debugRequest(options, response)
-					throw new errors.ResinRequestError(responseError, response.statusCode)
+					throw new errors.ResinRequestError(responseError, response.statusCode, options)
 
 				return response
 		.then(interceptResponse, interceptResponseError)

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "lodash": "^4.6.1",
     "progress-stream": "^1.1.1",
     "qs": "^6.3.0",
-    "resin-errors": "^2.3.0",
+    "resin-errors": "^2.5.0",
     "rindle": "^1.2.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
This ensures that whenever an error is thrown from an issue with a request, we include the request config with it - either by manually attaching it if `fetch` throws an exception itself (seems to throw a TypeError with `failed to fetch` typically), or by passing it to the constructor if we build our own `ResinRequestError`. I've nested the catch so we only do this with actual request errors, not any possible error that reaches this point. I'm a bit cautious of messing with the unknown exceptions that other interceptors might throw, or that we might get in our pre-request options & auth setup code.

This is building on top of https://github.com/resin-io-modules/resin-errors/pull/14, and is again part of https://github.com/resin-io/resin-ui/issues/400.

I considered moving all request errors to always be `ResinRequestError`s, which seems tidier all round, but this is sufficient. We could go further and do that, but it's a breaking change, and ResinRequestError expects a body & status which won't be the case for timeouts and similar. Worth investigating further, and breaking the api?