### PR TITLE
Fix bug with token error handling when code is minified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+- Fix bug with token error handling when code is minified
 - Added proxy support tests
 
 ## [8.4.0] - 2017-04-10

--- a/build/request.js
+++ b/build/request.js
@@ -81,7 +81,7 @@ module.exports = getRequest = function(arg) {
           baseUrl: baseUrl,
           refreshToken: false
         })["catch"]({
-          name: 'ResinRequestError',
+          code: 'ResinRequestError',
           statusCode: 401
         }, function() {
           return token.get().tap(token.remove).then(function(sessionToken) {

--- a/lib/request.coffee
+++ b/lib/request.coffee
@@ -77,7 +77,7 @@ module.exports = getRequest = ({
 				# however the fact that /whoami returns 401 allows
 				# us to safely assume the token is expired
 				.catch
-					name: 'ResinRequestError'
+					code: 'ResinRequestError'
 					statusCode: 401
 				, ->
 					return token.get().tap(token.remove).then (sessionToken) ->


### PR DESCRIPTION
`name` depends on the actual name of the class, which changes during minification. In this case, resin-ui would catch errors correctly in dev, but not in staging/production (as name was `t`). `code` meanwhile is reliable, so we should use that instead.

This is another fix out of resin-io/resin-ui#714.