### PR TITLE
chore: Install headless Chrome as a dev dependency

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,6 @@ cache:
 environment:
   matrix:
     - nodejs_version: 6
-    - nodejs_version: 4
 
 install:
   - ps: Install-Product node $env:nodejs_version x64

--- a/karma.conf.coffee
+++ b/karma.conf.coffee
@@ -1,7 +1,15 @@
-process = require('process')
 process.env.CHROME_BIN = require('puppeteer').executablePath()
 karmaConfig = require('resin-config-karma')
 packageJSON = require('./package.json')
+
+fs = require('fs')
+console.log('**********')
+console.log("CHROME_BIN: #{process.env.CHROME_BIN}")
+if fs.existsSync(process.env.CHROME_BIN)
+	console.log('CHROME_BIN: File exists')
+else
+	console.log('CHROME_BIN: FILE DOES NOT EXIST!')
+console.log('**********')
 
 module.exports = (config) ->
 	karmaConfig.plugins.push(require('karma-chrome-launcher'))
@@ -20,6 +28,7 @@ module.exports = (config) ->
 				'--disable-setuid-sandbox'
 				'--disable-translate'
 				'--disable-web-security'
+				'--disable-dev-shm-usage'
 			]
 
 	karmaConfig.logLevel = config.LOG_DEBUG

--- a/karma.conf.coffee
+++ b/karma.conf.coffee
@@ -1,15 +1,25 @@
+process = require('process')
 process.env.CHROME_BIN = require('puppeteer').executablePath()
 karmaConfig = require('resin-config-karma')
 packageJSON = require('./package.json')
 
 module.exports = (config) ->
 	karmaConfig.plugins.push(require('karma-chrome-launcher'))
-	karmaConfig.browsers = ['ChromeHeadless']
-	karmaConfig.flags = [
-		'--disable-web-security'
-		'--disable-gpu'
-		'--no-sandbox'
-	]
+	karmaConfig.browsers = ['HeadlessChrome']
+	karmaConfig.browserDisconnectTimeout = 60000
+	karmaConfig.browserDisconnectTolerance = 3
+	karmaConfig.browserNoActivityTimeout = 60000
+	karmaConfig.customLaunchers =
+		HeadlessChrome:
+			base: 'ChromeHeadless'
+			flags: [
+				'--no-sandbox'
+				'--headless'
+				'--disable-gpu'
+				'--disable-setuid-sandbox'
+				'--disable-translate'
+				'--disable-web-security'
+			]
 
 	karmaConfig.logLevel = config.LOG_INFO
 

--- a/karma.conf.coffee
+++ b/karma.conf.coffee
@@ -1,5 +1,6 @@
 karmaConfig = require('resin-config-karma')
 packageJSON = require('./package.json')
+process.env.CHROME_BIN = require('puppeteer').executablePath()
 
 module.exports = (config) ->
 	karmaConfig.plugins.push(require('karma-chrome-launcher'))

--- a/karma.conf.coffee
+++ b/karma.conf.coffee
@@ -1,10 +1,15 @@
+process.env.CHROME_BIN = require('puppeteer').executablePath()
 karmaConfig = require('resin-config-karma')
 packageJSON = require('./package.json')
-process.env.CHROME_BIN = require('puppeteer').executablePath()
 
 module.exports = (config) ->
 	karmaConfig.plugins.push(require('karma-chrome-launcher'))
 	karmaConfig.browsers = ['ChromeHeadless']
+	karmaConfig.flags = [
+		'--disable-web-security'
+		'--disable-gpu'
+		'--no-sandbox'
+	]
 
 	karmaConfig.logLevel = config.LOG_INFO
 

--- a/karma.conf.coffee
+++ b/karma.conf.coffee
@@ -14,6 +14,7 @@ module.exports = (config) ->
 			base: 'ChromeHeadless'
 			flags: [
 				'--no-sandbox'
+				'--no-proxy-server'
 				'--headless'
 				'--disable-gpu'
 				'--disable-setuid-sandbox'
@@ -21,7 +22,7 @@ module.exports = (config) ->
 				'--disable-web-security'
 			]
 
-	karmaConfig.logLevel = config.LOG_INFO
+	karmaConfig.logLevel = config.LOG_DEBUG
 
 	karmaConfig.sauceLabs =
 		testName: "#{packageJSON.name} v#{packageJSON.version}"

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "mochainon": "^1.0.0",
     "mockttp": "^0.8.0",
     "proxy": "^0.2.4",
+    "puppeteer": "^1.8.0",
     "resin-auth": "^2.0.0",
     "resin-config-karma": "^1.0.4",
     "temp": "^0.8.3",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "mochainon": "^1.0.0",
     "mockttp": "^0.8.0",
     "proxy": "^0.2.4",
-    "puppeteer": "^1.8.0",
+    "puppeteer": "~1.4.0",
     "resin-auth": "^2.0.0",
     "resin-config-karma": "^1.0.4",
     "temp": "^0.8.3",


### PR DESCRIPTION
Puppeteer does require Node v6.4.0 and as a result we had
to remove node v4 from appveyor.

Change-type: patch
Signed-off-by: Thodoris Greasidis <thodoris@resin.io>