### PR TITLE
Use resinCI for publishing to npm

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -28,45 +28,17 @@ jobs:
     working_directory: ~/node-8
     steps: *buildSteps
 
-  deploy:
-    # For this to work NPM_TOKEN must be set for the account used for publishing
-    docker:
-      - image: circleci/node:6-browsers
-    steps:
-      - attach_workspace:
-          at: $CIRCLE_WORKING_DIRECTORY
-      - run:
-          name: Login to npm
-          command: |
-            echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
-            npm whoami
-      - deploy:
-          name: Deploy to npm
-          command: npm publish
-          # Output used for publish is from node 6 build
-          working_directory: $CIRCLE_WORKING_DIRECTORY/node-6
-
 workflows:
   version: 2
   build:
     jobs:
       - "node-6":
-          # Run for all tags (required to allow the deploy to trigger on version tags)
+          # Run for all tags
           filters:
             tags:
               only: /.*/
       - "node-8":
-          # Run for all tags (required to allow the deploy to trigger on version tags)
+          # Run for all tags
           filters:
             tags:
               only: /.*/
-      - deploy:
-          # Deploy passing builds if they're tagged with a version
-          requires:
-            - "node-6"
-            - "node-8"
-          filters:
-            tags:
-              only: /^v\d+\.\d+\.\d+$/
-            branches:
-              ignore: /.*/

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "test-node": "gulp test",
     "test-browser": "mockttp -c karma start",
     "build": "gulp build",
-    "prepublish": "npm test && npm run build",
+    "prepublish": "require-npm4-to-publish",
+    "prepublishOnly": "npm run build",
     "readme": "jsdoc2md --template doc/README.hbs build/request.js build/progress.js build/utils.js > README.md"
   },
   "author": "Juan Cruz Viotti <juanchiviotti@gmail.com>",
@@ -42,6 +43,7 @@
     "mochainon": "^1.0.0",
     "mockttp": "^0.8.0",
     "proxy": "^0.2.4",
+    "require-npm4-to-publish": "^1.0.0",
     "resin-auth": "^2.0.0",
     "resin-config-karma": "^1.0.4",
     "temp": "^0.8.3",


### PR DESCRIPTION
Stops using circleCI for npm deploys.
No longer runs the tests before publishing, since that resinCI
step is meant to be really slim and also the image used doesn't
have Chrome installed (see attached discussion).
Should not be a concern since:
* the tests were run before merging to master
* we are moving away from manual publishing.
  ResinCI requires zero configuration so most of the time
  there is no reason to publish anything manually.

Resolves: #126
Change-type: patch
See: https://www.flowdock.com/app/rulemotion/r-beginners/threads/fnuvWdmMTYdgY4sAitqaYvA0-f3
Signed-off-by: Thodoris Greasidis <thodoris@resin.io>